### PR TITLE
Fix XLMR model type naming bug

### DIFF
--- a/scripts/train_qa.sh
+++ b/scripts/train_qa.sh
@@ -31,7 +31,7 @@ if [ $MODEL == "bert-base-multilingual-cased" ]; then
 elif [ $MODEL == "xlm-mlm-100-1280" ] || [ $MODEL == "xlm-mlm-tlm-xnli15-1024" ]; then
   MODEL_TYPE="xlm"
 elif [ $MODEL == "xlm-roberta-large" ] || [ $MODEL == "xlm-roberta-base" ]; then
-  MODEL_TYPE="xlmr"
+  MODEL_TYPE="xlm-roberta"
 fi
 
 # Model path where trained model should be stored


### PR DESCRIPTION
```run_squad.py``` expects model type to be ```xlm-roberta``` and not ```xlmr```. Otherwise, scripts fail.