### PR TITLE
Update SquadPreprocessor to work with latest transformers 2.8

### DIFF
--- a/third_party/processors/squad.py
+++ b/third_party/processors/squad.py
@@ -145,6 +145,7 @@ def squad_convert_example_to_features(example, max_seq_length, doc_stride, max_q
             pad_to_max_length=True,
             stride=max_seq_length - doc_stride - len(truncated_query) - sequence_pair_added_tokens,
             truncation_strategy="only_second" if tokenizer.padding_side == "right" else "only_first",
+            return_token_type_ids=True
         )
 
         paragraph_len = min(


### PR DESCRIPTION
```install_tools.sh``` script installs the latest version of ```transformers```.
There was a breaking change affecting XLMR in the latest version. 
I also suggest pinning ```transformers``` version to avoid such problems in the future.