### PR TITLE
Panx download data fixes

### DIFF
--- a/conda-env.txt
+++ b/conda-env.txt
@@ -20,7 +20,7 @@ https://conda.anaconda.org/anaconda/linux-64/libsodium-1.0.16-h1bed415_0.tar.bz2
 https://conda.anaconda.org/anaconda/linux-64/libuuid-1.0.3-h1bed415_2.tar.bz2
 https://conda.anaconda.org/anaconda/linux-64/libxcb-1.13-h1bed415_1.tar.bz2
 https://repo.anaconda.com/pkgs/main/linux-64/ncurses-6.1-he6710b0_1.tar.bz2
-https://conda.anaconda.org/anaconda/linux-64/openssl-1.1.1-h7b6447c_0.tar.bz2
+https://conda.anaconda.org/anaconda/linux-64/openssl-1.1.1g-h7b6447c_0.tar.bz2
 https://conda.anaconda.org/anaconda/linux-64/pcre-8.43-he6710b0_0.tar.bz2
 https://repo.anaconda.com/pkgs/main/linux-64/xz-5.2.4-h14c3975_4.tar.bz2
 https://repo.anaconda.com/pkgs/main/linux-64/zlib-1.2.11-h7b6447c_3.tar.bz2

--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -87,13 +87,15 @@ function download_udpos {
 function download_panx {
     echo "Download panx NER dataset"
     if [ -f $DIR/AmazonPhotos.zip ]; then
-        unzip -qq $DIR/AmazonPhotos.zip -d $DIR/
-        base_dir=$DIR/panx_dataset/ && cd $base_dir
+        base_dir=$DIR/panx_dataset/
+        unzip -qq $DIR/AmazonPhotos.zip -d $base_dir
+        cd $base_dir
         langs=(ar he vi id jv ms tl eu ml ta te af nl en de el bn hi mr ur fa fr it pt es bg ru ja ka ko th sw yo my zh kk tr et fi hu)
         for lg in ${langs[@]}; do
             tar xzf $base_dir/${lg}.tar.gz
             for f in dev test train; do mv $base_dir/$f $base_dir/${lg}-${f}; done
         done
+        cd ..
         python $REPO/utils_preprocess.py \
             --data_dir $base_dir \
             --output_dir $DIR/panx \


### PR DESCRIPTION
Hi,

this PR fixes two issues:

1. the anaconda env file cannot be installed sucessfully, because the specified version of `openssl` returned a 404. The PR uses a working version now.

2. The panx routine in the `download_data.sh` script originally unzipped the files into the download folder instead of a `panx_dataset` temp folder, so the `tar` command couldn't find the archives.