### PR TITLE
Update run_tatoeba.sh

### DIFF
--- a/scripts/run_tatoeba.sh
+++ b/scripts/run_tatoeba.sh
@@ -45,7 +45,7 @@ fi
 OUT=$OUT_DIR/$TASK/${MODEL}_${MAXL}/
 mkdir -p $OUT
 for SL in ar he vi id jv tl eu ml ta te af nl en de el bn hi mr ur fa fr it pt es bg ru ja ka ko th sw zh kk tr et fi hu; do
-  python $REPO/third_party/run_retrieval.py \
+  python $REPO/third_party/evaluate_retrieval.py \
     --model_type $MODEL_TYPE \
     --model_name_or_path $MODEL \
     --embed_size $DIM \


### PR DESCRIPTION
The run_retrieval.py has been renamed to evaluate_retrieval.py  in commit c168376, update this file to align with this change