### PR TITLE
Corrected the xnli processor first-line bug

### DIFF
--- a/third_party/processors/xnli.py
+++ b/third_party/processors/xnli.py
@@ -39,8 +39,6 @@ class XnliProcessor(DataProcessor):
         lines = self._read_tsv(os.path.join(data_dir, "{}-{}.tsv".format(split, lg)))
         
         for (i, line) in enumerate(lines):
-          if i == 0:
-            continue
           guid = "%s-%s-%s" % (split, lg, i)
           text_a = line[0]
           text_b = line[1]


### PR DESCRIPTION
The original processor will skip the first line of XNLI examples, this correction will make it compatible with XTREME leaderboard evaluation script.