### PR TITLE
Update name of the script to run in run_bucc2018.sh

### DIFF
--- a/scripts/run_bucc2018.sh
+++ b/scripts/run_bucc2018.sh
@@ -55,7 +55,7 @@ for SL in fr ru zh de; do
   done
 
   CP="candidates"
-  python $REPO/third_party/run_retrieval.py \
+  python $REPO/third_party/evaluate_retrieval.py \
     --model_type $MODEL_TYPE \
     --model_name_or_path $MODEL \
     --embed_size $DIM \


### PR DESCRIPTION
Fix #68  by fixing name of the script from `run_retrieval.py` to `evaluate_retrieval.py` in run_bucc2018.sh