### PR TITLE
Fix #75 by adding optional parameter to bucc_extract for setting encoding type

### DIFF
--- a/third_party/utils_retrieve.py
+++ b/third_party/utils_retrieve.py
@@ -249,9 +249,9 @@ def bucc_optimize(candidate2score, gold):
   return threshold
 
 
-def bucc_extract(cand2score, th, fname):
+def bucc_extract(cand2score, th, fname, encoding='utf-8'):
   if fname:
-    of = open(fname, 'w', encoding=args.encoding)
+    of = open(fname, 'w', encoding=encoding)
   bitexts = []
   for (src, trg), score in cand2score.items():
     if score >= th:


### PR DESCRIPTION
This PR solves the erroneous typo in bucc_extract() without changing any related code. Note that this PR will prevent errors but the behavior will stay the same, so this PR doesn't maintain related functions to pass args.encoding to all the related functions.