### PR TITLE
Fix tatoeba dataset branch name: master -> main

### DIFF
--- a/scripts/download_data.sh
+++ b/scripts/download_data.sh
@@ -111,14 +111,14 @@ function download_panx {
 
 function download_tatoeba {
     base_dir=$DIR/tatoeba-tmp/
-    wget https://github.com/facebookresearch/LASER/archive/master.zip
-    unzip -qq -o master.zip -d $base_dir/
-    mv $base_dir/LASER-master/data/tatoeba/v1/* $base_dir/
+    wget https://github.com/facebookresearch/LASER/archive/main.zip
+    unzip -qq -o main.zip -d $base_dir/
+    mv $base_dir/LASER-main/data/tatoeba/v1/* $base_dir/
     python $REPO/utils_preprocess.py \
       --data_dir $base_dir \
       --output_dir $DIR/tatoeba \
       --task tatoeba
-    rm -rf $base_dir master.zip
+    rm -rf $base_dir main.zip
     echo "Successfully downloaded data at $DIR/tatoeba" >> $DIR/download.log
 }
 


### PR DESCRIPTION
It seems the repository for the tatoeba dataset (https://github.com/facebookresearch/LASER/) renamed their branch from `master` to `main`, which breaks the `download_data.sh` script. I fixed the issue #79 by renaming the branch in the download script as well.