### PR TITLE
Solve initialization in tatoeba and bucc2018

### DIFF
--- a/scripts/run_bucc2018.sh
+++ b/scripts/run_bucc2018.sh
@@ -63,7 +63,7 @@ for SL in fr ru zh de; do
     --task_name $TASK \
     --src_language $SL \
     --tgt_language $TL \
-    --pool_type cls \
+    --pool_type mean \
     --max_seq_length $MAXL \
     --data_dir $DATA_DIR \
     --output_dir $OUT \

--- a/scripts/run_tatoeba.sh
+++ b/scripts/run_tatoeba.sh
@@ -34,11 +34,14 @@ elif [ $MODEL == "xlm-mlm-100-1280" ] || [ $MODEL == "xlm-mlm-tlm-xnli15-1024" ]
   MODEL_TYPE="xlm"
   LC=" --do_lower_case"
   DIM=1280
-elif [ $MODEL == "xlm-roberta-large" ] || [ $MODEL == "xlm-roberta-base" ]; then
+elif [ $MODEL == "xlm-roberta-base" ]; then
+  MODEL_TYPE="bert"
+  DIM=768
+elif [ $MODEL == "xlm-roberta-large" ]; then
   MODEL_TYPE="xlmr"
   DIM=1024
   NLAYER=24
-  LAYER=13
+  LAYER=10
 fi
 
 # Add fine-tuned model path here


### PR DESCRIPTION
Hi!

I know that I am arriving a bit late, but thanks for this repo! I would just like to correct two issues that would allow ease of comparison in future analysis.

- As explained in the paper, in the bucc task it was important to perform an average of the tokens, taking the cls token gave worse performance. However, I found that your default configuration used cls.

- In the tatoeba task there is also a mistake in the initialization, in the case of the xlm-roberta-large I checked that the performance of the model was only equal to your numbers when the retrieval is extracted from the layer 10.